### PR TITLE
add patch to fix the recursive-symlink-problem

### DIFF
--- a/recipes-kernel/linux/linux-hardkernel-3.4/odroid-xu/fix-broken-creation-of-arch-release-symlink.patch
+++ b/recipes-kernel/linux/linux-hardkernel-3.4/odroid-xu/fix-broken-creation-of-arch-release-symlink.patch
@@ -1,0 +1,25 @@
+# i don't exactly get whats going wrong here. but the build-system somehow
+# calls the "ln" inside the "arch" dir, where a symlink pointing to itself is
+# created... this will fool later stages of the build-process.
+#
+# anyhow, this seems to "fix" it -- meaning in the case observer, no symlink
+# what-so-ever is created... meh...
+#
+# to be explcicit: this fix works accidentally, the root-cause was not understood ;-)
+#
+# after a bit of research: the commit 9a3fbdc18fca5adc117ad6b505a625859adb969e
+# in git://github.com/hardkernel/linux.git removes the "arch-release" directory
+# and 73341c84ade21b97091b0289a9ddfc00900c038b readds it.  besides this, this
+# driver seems to be relatively calm... well, propriatary software development:
+# one initial "eat-my-shit" dump, and off they go. stupid
+--- linux/drivers/gpu/arm/mali400/ump/Kbuild	2014-07-30 15:44:03.984805492 +0200
++++ linux/drivers/gpu/arm/mali400/ump/Kbuild	2014-07-30 15:44:39.609139070 +0200
+@@ -21,7 +21,7 @@
+ else
+ # Link arch to the selected arch-config directory
+ $(shell [ -L $(src)/arch ] && rm $(src)/arch)
+-$(shell ln -sf arch-$(CONFIG) $(src)/arch)
++$(shell ln -sf $(src)/arch-$(CONFIG) $(src)/arch)
+ $(shell touch $(src)/arch/config.h)
+ endif
+ 

--- a/recipes-kernel/linux/linux-hardkernel_3.4.bb
+++ b/recipes-kernel/linux/linux-hardkernel_3.4.bb
@@ -24,4 +24,5 @@ PV = "${LINUX_VERSION}"
 SRC_URI = " \
   ${KERNEL_REPO_URI};nocheckout=1;branch=${KBRANCH} \
   file://defconfig \
+  file://fix-broken-creation-of-arch-release-symlink.patch \
 "


### PR DESCRIPTION
was not caused by bitbake. this would be the once-in-a-lifetime chance
to submit a patch to _the_ kernel-tree ;-) if they would track the
mali400 driver...

only fixed for 3.4, but the problem should be in the rest as well?

Signed-off-by: Martin Zenzes martin.zenzes@dfki.de
