### PR TITLE
u-boot: Add COMPATIBLE_MACHINE and blacklist broken recipe

### DIFF
--- a/recipes-bsp/u-boot-hardkernel/u-boot-hardkernel_2012.07.bb
+++ b/recipes-bsp/u-boot-hardkernel/u-boot-hardkernel_2012.07.bb
@@ -35,4 +35,6 @@ do_deploy_append () {
     cp -v ${WORKDIR}/sd_fusing.sh ${DEPLOYDIR}
 }
 
+COMPATIBLE_MACHINE = "(odroid-xu)"
+
 PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/recipes-bsp/u-boot-hardkernel/u-boot-hardkernel_alpha4.bb
+++ b/recipes-bsp/u-boot-hardkernel/u-boot-hardkernel_alpha4.bb
@@ -6,6 +6,8 @@ LICENSE = "GPLv2"
 
 PR = "r1"
 
+PNBLACKLIST[u-boot-hardkernel] ?= "BROKEN: download source doesn't exist; COMPATIBLE_MACHINE isn't specified"
+
 inherit deploy
 
 LIC_FILES_CHKSUM = "file://sd_fusing.sh;md5=9343188afe21ccc8e061d6f0fe9a8fd9;endline=10"


### PR DESCRIPTION
Hi,

this is another small cleanup commit.

And two not so related things:
1) Were you thinking about enabling github issues for your meta-odroid? It would be better way to talk than messages in pull requests.
2) I think that It would be good to fork current master into dylan and let it be. My work on ODROID-C1 is tested only on dizzy and should be merged only into your master (and dizzy should be forked afterwards?).
Thanks and best regards,

Tomas
